### PR TITLE
fix typo in context proposal

### DIFF
--- a/proposals/context.md
+++ b/proposals/context.md
@@ -172,7 +172,7 @@ class SimpleElement extends HTMLElement {
         (value, dispose) => {
           // protect against changing providers
           if (dispose && dispose !== this.loggerDisposer) {
-            this.dispose();
+            this.loggerDisposer();
           }
           this.logger = value;
           this.loggerDisposer = dispose;


### PR DESCRIPTION
I believe this is meant to be `loggerDisposer()` - disposing of the old provider, to start using the new one.