### PR TITLE
[context] promote to candidate status

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Check out the [Issues](https://github.com/webcomponents/community-protocols/issu
 
 ## Proposals
 
-| Proposal       | Author           | Status |
-|----------------|------------------|--------|
-| [Context]      | Benjamin Delarre | Draft  |
-| [Pending Task] | Justin Fagnani   | Draft  |
+| Proposal       | Author           | Status     |
+|----------------|------------------|------------|
+| [Context]      | Benjamin Delarre | Candidate  |
+| [Pending Task] | Justin Fagnani   | Draft      |
 
 [Context]: https://github.com/webcomponents/community-protocols/blob/main/proposals/context.md
 [Pending Task]: https://github.com/webcomponents/community-protocols/blob/main/proposals/pending-task.md

--- a/proposals/context.md
+++ b/proposals/context.md
@@ -4,7 +4,7 @@ An open protocol for data passing between components.
 
 Author: Benjamin Delarre
 
-Document status: Draft
+Document status: Candidate
 
 Last update: 2021-8-26
 


### PR DESCRIPTION
This may be overly provocative but there's been a lot of conversation about this API, some settling in its various consumptions and iterations along the way, it seems like it _might_ be time to promote it to "Candidate".

Thoughts?

REMINDER: the WCCG is having its November meeting on Tuesday the 7th at 12pm ET. Join us on [Discord](https://discord.gg/6MMW4vvBgX) to learn more!